### PR TITLE
Fixed out of context problem

### DIFF
--- a/ckanext/generalpublic/middleware.py
+++ b/ckanext/generalpublic/middleware.py
@@ -34,13 +34,9 @@ class AuthMiddleware(object):
 
             x = pathInfo.split("/")
 
-            data = {'id': x[2]}
+            data = {'packageid': x[2]}
 
-            testers  = toolkit.get_action('package_show')({'ignore_auth': True}, data)
-
-            data2 = {'packageid': testers["id"]}
-
-            ispublic = toolkit.get_action('get_package_visibility')({'ignore_auth': True}, data2)
+            ispublic = toolkit.get_action('get_package_visibility')({'ignore_auth': True}, data)
 
             try:
                 if ispublic.visibility == "Public":


### PR DESCRIPTION
Package show actionapi causes out of context problem. This takes off package show and simplifies shop window pipeline while doing so.