### PR TITLE
Fix dataset search sort for users not logged in

### DIFF
--- a/ckanext/generalpublic/middleware.py
+++ b/ckanext/generalpublic/middleware.py
@@ -48,8 +48,8 @@ class AuthMiddleware(object):
                 
             return ['']
 
-        # Dont allow API
-        elif '/api/' in pathInfo or '/datastore/dump/' in pathInfo:
+        # Dont allow datastore dump
+        elif '/datastore/dump/' in pathInfo:
             self.goToLogin(environ,start_response)
             return ['']
         


### PR DESCRIPTION
Search sorts require access to API. I have tested and allowing none logged in users access to the API does not give them any additional permissions.