### PR TITLE
Allow images to be seen by users not logged in

### DIFF
--- a/ckanext/generalpublic/middleware.py
+++ b/ckanext/generalpublic/middleware.py
@@ -25,7 +25,7 @@ class AuthMiddleware(object):
             return self.app(environ,start_response)
 
         # Dont allow downloads/uploads
-        elif '/uploads/' in pathInfo or '/download/' in pathInfo:
+        elif '/download/' in pathInfo:
             self.goToLogin(environ,start_response)
             return ['']
 


### PR DESCRIPTION
Uploads only contain the images uploaded where as downloads is where all the datasets are stored. So allowing none logged in users access to images will not be a problem